### PR TITLE
Nw post get mvp

### DIFF
--- a/Models/Posts.cs
+++ b/Models/Posts.cs
@@ -5,10 +5,10 @@
         public int Id { get; set; }
         public int UserId { get; set; }
         public int CategoryId { get; set; }
-        public string Title { get; set; }
+        public string? Title { get; set; }
         public DateTime PublicationDate { get; set; }
-        public string ImageUrl { get; set; }
-        public string Content { get; set; }
+        public string? ImageUrl { get; set; }
+        public string? Content { get; set; }
         public bool Approved { get; set; }
     }
 }

--- a/Models/Users.cs
+++ b/Models/Users.cs
@@ -5,13 +5,13 @@ namespace rare.Models
     public class Users
     {
         public int Id { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string Email { get; set; }
-        public string Bio { get; set; }
-        public string Username { get; set; }
-        public string Password  { get; set; }
-        public string ProfileImageUrl { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+        public string? Bio { get; set; }
+        public string? Username { get; set; }
+        public string? Password  { get; set; }
+        public string? ProfileImageUrl { get; set; }
         public DateTime CreatedOn { get; set; }
         public bool Active { get; set; }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -278,5 +278,15 @@ app.MapGet("/users/{id}", (int id) => {
     return Results.Ok(user);
 });
 
+// GET POST
+app.MapGet("/api/posts", () => Results.Ok(posts));
+
+//GET POST BY ID
+app.MapGet("/api/posts/{id}", (int id) =>
+{
+    var post = posts.FirstOrDefault(p => p.Id == id);
+    return post != null ? Results.Ok(post) : Results.NotFound();
+});
+
 
 app.Run();

--- a/Program.cs
+++ b/Program.cs
@@ -248,3 +248,30 @@ List<Reactions> reactions = new List<Reactions>
         Emoji = ":joy:"
     }
 };
+
+var builder = WebApplication.CreateBuilder(args);
+
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.MapGet("/api/posts", () => Results.Ok(posts));
+
+app.MapGet("/api/posts/{id}", (int id) =>
+{
+    var post = posts.FirstOrDefault(p => p.Id == id);
+    return post != null ? Results.Ok(post) : Results.NotFound();
+});
+
+
+app.Run();


### PR DESCRIPTION
## Description
Implemented two endpoints in the minimal API: one for fetching all posts and another for fetching a specific post by ID. The first endpoint responds to GET requests at `/api/posts` and returns all posts. The second endpoint responds to GET requests at `/api/posts/{id}`, returning the post with the specified ID if it exists, or a 404 Not Found response if it does not.


## Motivation and Context
The addition of these endpoints is crucial for the frontend to display posts to users and to allow users to view details of specific posts. It enhances the API's functionality by supporting basic operations required for a blogging platform or a content management system.


## How Can This Be Tested?
By adding the endpoints to postman.
http://localhost:5209/api/posts
http://localhost:5209/api/posts/1


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)