### PR TITLE
DELETE POST

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -288,6 +288,17 @@ app.MapGet("/api/posts/{id}", (int id) =>
     return post != null ? Results.Ok(post) : Results.NotFound();
 });
 
+//DELETE POST
+app.MapDelete("/api/posts/{id}", (int id) =>
+{
+    var post = posts.FirstOrDefault(p => p.Id == id);
+    if (post == null) return Results.NotFound();
+
+    posts.Remove(post);
+    return Results.Ok(new { message = "Post deleted successfully." });
+});
+
+
 //POST Comment to POST
 app.MapPost("/posts/{postId}/comments", (int postId, Comments comment) =>
 {


### PR DESCRIPTION
## Description
Implemented a DELETE endpoint for the minimal API that allows for deleting a specific post by its unique identifier (ID). The endpoint listens to DELETE requests at `/api/posts/{id}`. Upon receiving a request, it searches for the post with the given ID, deletes it if found, and returns a success message. If no matching post is found, a 404 Not Found response is returned to the client.

## Motivation and Context
The addition of this endpoint enhances the API's content management capabilities, allowing users or administrators to remove posts that are outdated, irrelevant, or inappropriate. This feature is essential for maintaining the quality and relevance of the content available through the API. It also addresses potential user feedback or compliance requirements by providing a mechanism to remove content efficiently.

## How Can This Be Tested?
Adding DELETE endpoint to Postman
http://localhost:5209/api/posts/1

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)