### PR TITLE
SUBSCRIPTIONS - GET BY USER ID (EXTRA, FOR TESTING), POST, DELETE

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -373,10 +373,23 @@ app.MapDelete("/tags/{id}", (int id) =>
     return Results.Ok(tag);
 });
 
+
+// GET SUBSCRIPTIONS BY USER
+app.MapGet("/subscription/{id}", (int id) => {
+    Subscriptions subs = subscriptions.Where(u => u.FollowerId == id).ToList();
+    if (subs == null)
+    {
+        return Results.NotFound();
+    }
+    return Results.Ok(subs);
+});
+
+
 // POST - ASSOCIATE SUBSCRIPTION 
 app.MapPost("/subscription", (Subscriptions subscription) =>
 {
     subscription.Id = subscriptions.Max(st => st.Id) + 1;
+    subscription.CreatedOn = DateTime.Now;
     subscriptions.Add(subscription);
     return subscription;
 });

--- a/Program.cs
+++ b/Program.cs
@@ -362,4 +362,15 @@ app.MapDelete("/tags/{id}", (int id) =>
     return Results.Ok(tag);
 });
 
+// POST - ASSOCIATE SUBSCRIPTION 
+app.MapPost("/subscription", (Subscriptions subscription) =>
+{
+    // creates a new id (When we get to it later, our SQL database will do this for us like JSON Server did!)
+    subscription.Id = subscriptions.Max(st => st.Id) + 1;
+    subscriptions.Add(subscription);
+    return subscription;
+});
+
+// DELETE - DISASSOCIATE SUBSCRIPTION
+
 app.Run();

--- a/Program.cs
+++ b/Program.cs
@@ -376,7 +376,7 @@ app.MapDelete("/tags/{id}", (int id) =>
 
 // GET SUBSCRIPTIONS BY USER
 app.MapGet("/subscription/{id}", (int id) => {
-    Subscriptions subs = subscriptions.Where(u => u.FollowerId == id).ToList();
+    var subs = subscriptions.Where(u => u.FollowerId == id).ToList();
     if (subs == null)
     {
         return Results.NotFound();

--- a/Program.cs
+++ b/Program.cs
@@ -376,12 +376,22 @@ app.MapDelete("/tags/{id}", (int id) =>
 // POST - ASSOCIATE SUBSCRIPTION 
 app.MapPost("/subscription", (Subscriptions subscription) =>
 {
-    // creates a new id (When we get to it later, our SQL database will do this for us like JSON Server did!)
     subscription.Id = subscriptions.Max(st => st.Id) + 1;
     subscriptions.Add(subscription);
     return subscription;
 });
 
 // DELETE - DISASSOCIATE SUBSCRIPTION
+app.MapDelete("/subscription/{id}", (int id) =>
+{
+    Subscriptions subscriptionToDelete = subscriptions.FirstOrDefault(sub => sub.Id == id);
+    if (subscriptionToDelete == null)
+    {
+        return Results.NotFound();
+    };
+    subscriptions.Remove(subscriptionToDelete);
+    return Results.Ok();
+});
+
 
 app.Run();


### PR DESCRIPTION
## Description
- Created the POST and the DELETE subscription API call, as well as a GET API call for testing. When given a UID, the GET API call will obtain all the different subscriptions the provided user has. 

## Related Issue
#23 and #24 

## Motivation and Context
This is core functionality of the application.

## How Can This Be Tested?
- Pull local PR branch to test branch
- Test utilizing written Postman calls within shared collection. You may need to change localhost port. 

## Screenshots (if appropriate):
N / A 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)